### PR TITLE
Remove Terminate Session Packet at the end

### DIFF
--- a/haproxy-example.cfg
+++ b/haproxy-example.cfg
@@ -147,10 +147,6 @@ backend backend_pg
     tcp-check expect binary 00000001               # column length in bytes: 1
     tcp-check expect binary 66                     # column data, "f"
 
-# write: terminate session
-    tcp-check send-binary 58                       # Termination packet
-    tcp-check send-binary 00000004                 # packet length: 4 (no body)
-
 # close open sessions in case the downed server is still running but is out of sync with the master
     default-server on-marked-down shutdown-sessions
 

--- a/template/redirect.template
+++ b/template/redirect.template
@@ -126,6 +126,10 @@ backend good_backend_pg
     tcp-check send-binary 00 # terminator                                       (  1 byte  )
                                                    ## TOTAL                     ( 32 bytes )
 
+# write: terminate session
+    tcp-check send-binary 58                       # Termination packet
+    tcp-check send-binary 00000004                 # packet length: 4 (no body)
+
 # expect: Row description packet
 #
 tcp-check expect binary 54                         # row description packet
@@ -152,9 +156,6 @@ tcp-check expect binary 54                         # row description packet
     tcp-check expect binary 00000001               # column length in bytes: 1  (  4 bytes )
     tcp-check expect binary 66                     # column data, "f"           (  1 byte  )
                                                    ## TOTAL                     ( 11 bytes )
-# write: terminate session
-    tcp-check send-binary 58                       # Termination packet
-    tcp-check send-binary 00000004                 # packet length: 4 (no body)
 
     acl client_redirected src <%= @bn.masterip %>
     if client_redirected use new_backend

--- a/template/standby.template
+++ b/template/standby.template
@@ -150,9 +150,6 @@ tcp-check expect binary 54                         # row description packet
     tcp-check expect binary 00000001               # column length in bytes: 1  (  4 bytes )
     tcp-check expect binary 66                     # column data, "f"           (  1 byte  )
                                                    ## TOTAL                     ( 11 bytes )
-# write: terminate session
-    tcp-check send-binary 58                       # Termination packet
-    tcp-check send-binary 00000004                 # packet length: 4 (no body)
 
 # close open sessions in case the downed server is still running but is out of sync with the master
     default-server on-marked-down shutdown-sessions


### PR DESCRIPTION
For the issue #1, on my setup, I have removed the last Terminate Session Packet. Because, if I understand correctly, the session is already close by the first Terminate Session Packet. @gplv2 what do you think ?